### PR TITLE
Add EntryPoint config parameter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,10 @@ type File struct {
 	//`go build` would be executed in.
 	WorkingDir string `yaml:"WorkingDir"`
 
+	//EntryPoint is the path to the main package, which is passed to `go run` or
+	//`go build` commands. Defaults to '.'.
+	EntryPoint string `yaml:"EntryPoint"`
+
 	//TempDir is the directory off of WorkingDir where fresher will store the built
 	//binary, that will be run, and error logs.
 	TempDir string `yaml:"TempDir"`
@@ -137,6 +141,7 @@ func newDefaultConfig() (f *File) {
 
 	f = &File{
 		WorkingDir:             workingDir,
+		EntryPoint:             ".",
 		TempDir:                filepath.Join(workingDir, "tmp"),
 		ExtensionsToWatch:      []string{".go", ".html"},
 		NoRebuildExtensions:    []string{".html"},
@@ -307,6 +312,12 @@ func (conf *File) validate() (err error) {
 	conf.WorkingDir = filepath.FromSlash(strings.TrimSpace(conf.WorkingDir))
 	if conf.WorkingDir == "" {
 		return errors.New("config: WorkingDir not set. Typically this should be set to \".\"")
+	}
+
+	//Make sure entry point directory is set. This might be "." or any other path.
+	conf.EntryPoint = strings.TrimSpace(conf.EntryPoint)
+	if conf.EntryPoint == "" {
+		return errors.New("config: EntryPoint not set. Typically this should be set to \".\"")
 	}
 
 	//Make sure temp directory is somewhat valid looking.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,15 @@ func TestValidate(t *testing.T) {
 	}
 	cfg.WorkingDir = "."
 
+	//Edit the config to break things.
+	cfg.EntryPoint = ""
+	err = cfg.validate()
+	if err == nil {
+		t.Fatal("Error about bad EntryPoint should have been returned.")
+		return
+	}
+	cfg.EntryPoint = "."
+
 	//Test defaults being set.
 	cfg.TempDir = ""
 	err = cfg.validate()

--- a/runner3/runner3.go
+++ b/runner3/runner3.go
@@ -386,7 +386,7 @@ func build(event fsnotify.Event) (err error) {
 	//Not naming a single "main.go" file allows for using any .go filename as the
 	//entry point, and using multiple .go files at once; go build figures this all
 	//out.
-	entryPoint := config.Data().WorkingDir
+	entryPoint := config.Data().EntryPoint
 
 	//Add the entry point to build the binary from.
 	args = append(args, entryPoint)


### PR DESCRIPTION
This allows to specify custom 'main' path, like `cmd/x` or `github.com/user/app/cmd/x`.